### PR TITLE
update oauth_url in api class

### DIFF
--- a/blizzardapi2/api.py
+++ b/blizzardapi2/api.py
@@ -30,7 +30,7 @@ class Api:
         self._api_url = "https://{0}.api.blizzard.com{1}"
         self._api_url_cn = "https://gateway.battlenet.com.cn{0}"
 
-        self._oauth_url = "https://{0}.api.blizzard.com{1}"
+        self._oauth_url = "https://oauth.battle.net{1}"
         self._oauth_url_cn = "https://www.gateway.battlenet.com.cn{0}"
 
         self._session = requests.Session()


### PR DESCRIPTION
As stated in Issue #12 , The `us.api.blizzard.com/oauth/token` endpoint is returning a 404 error. `oauth.battle.net/token` is the correct endpoint.


