### PR TITLE
Resolve seven follow-ups surfaced by the PR #38 test suite

### DIFF
--- a/blizzardapi2/api.py
+++ b/blizzardapi2/api.py
@@ -33,6 +33,12 @@ class BaseApi:
 
     TOKEN_REFRESH_BUFFER = timedelta(minutes=5)
 
+    # Per-request timeouts (seconds). Subclass and override either constant
+    # to customize. `requests` defaults to no timeout, which lets a hung
+    # Blizzard endpoint wedge the caller indefinitely.
+    DEFAULT_GET_TIMEOUT = 30.0
+    DEFAULT_POST_TIMEOUT = 10.0
+
     def __init__(self, client_id: str, client_secret: str) -> None:
         """Initialize the API client.
 
@@ -66,6 +72,7 @@ class BaseApi:
             url,
             params={"grant_type": "client_credentials"},
             auth=(self._client_id, self._client_secret),
+            timeout=self.DEFAULT_POST_TIMEOUT,
         )
         response.raise_for_status()
         token_data = response.json()
@@ -147,6 +154,7 @@ class BaseApi:
             url,
             params=params,
             headers={"Authorization": f"Bearer {token}"},
+            timeout=self.DEFAULT_GET_TIMEOUT,
         )
 
         # Handle 401 errors for client credentials (not user tokens)
@@ -157,6 +165,7 @@ class BaseApi:
                 url,
                 params=params,
                 headers={"Authorization": f"Bearer {self._access_token}"},
+                timeout=self.DEFAULT_GET_TIMEOUT,
             )
 
         response.raise_for_status()

--- a/blizzardapi2/battlenet/battlenet_api.py
+++ b/blizzardapi2/battlenet/battlenet_api.py
@@ -1,7 +1,5 @@
 """battlenet_api.py file."""
 
-from typing import Any
-
 from .battlenet_oauth_api import BattlenetOAuthApi
 
 
@@ -13,6 +11,6 @@ class BattlenetApi:
         client_secret (str): A string client secret supplied by Blizzard.
     """
 
-    def __init__(self, client_id: str, client_secret: str) -> dict[str, Any]:
+    def __init__(self, client_id: str, client_secret: str) -> None:
         """Init BattlenetApi."""
         self.oauth = BattlenetOAuthApi(client_id, client_secret)

--- a/blizzardapi2/battlenet/battlenet_oauth_api.py
+++ b/blizzardapi2/battlenet/battlenet_oauth_api.py
@@ -40,11 +40,13 @@ class BattlenetOAuthApi(BaseApi):
         """
         super().__init__(client_id, client_secret)
 
-    def get_user_info(self, region: Region, access_token: str) -> dict[str, Any]:
+    def get_user_info(self, region: Region | str, access_token: str) -> dict[str, Any]:
         """Get basic information about the user associated with the current bearer token.
 
         Args:
-            region: The region to query (e.g., "us", "eu").
+            region: The region to query — either a ``Region`` enum member or
+                a bare string (e.g. ``"us"`` or ``Region.US``). Bare strings
+                are accepted for ergonomics and parity with the other game APIs.
             access_token: The OAuth access token.
 
         Returns:

--- a/blizzardapi2/battlenet/battlenet_oauth_api.py
+++ b/blizzardapi2/battlenet/battlenet_oauth_api.py
@@ -51,7 +51,8 @@ class BattlenetOAuthApi(BaseApi):
             A dictionary containing user information.
 
         Raises:
-            ApiError: If the API request fails.
+            requests.HTTPError: If the API request fails (raised via
+                ``response.raise_for_status()`` in ``BaseApi._make_request``).
         """
         resource = "/oauth/userinfo"
         query_params = {

--- a/blizzardapi2/diablo3/diablo3_community_api.py
+++ b/blizzardapi2/diablo3/diablo3_community_api.py
@@ -255,7 +255,7 @@ class Diablo3CommunityApi(BaseApi):
         self, region: str, locale: str, account_id: str, hero_id: int
     ) -> dict[str, Any]:
         """
-        Return a single item by item slug and ID.
+        Return the equipped follower items for a given hero.
 
         Args:
             region (str): The region to query.
@@ -264,7 +264,8 @@ class Diablo3CommunityApi(BaseApi):
             hero_id (int): The ID of the hero.
 
         Returns:
-            Dict[str, Any]: A dictionary containing the item details.
+            Dict[str, Any]: A dictionary containing the follower items
+                equipped on the specified hero.
         """
         resource = f"/d3/profile/{account_id}/hero/{hero_id}/follower-items"
         query_params = {"locale": locale}

--- a/blizzardapi2/hearthstone/hearthstone_api.py
+++ b/blizzardapi2/hearthstone/hearthstone_api.py
@@ -1,13 +1,16 @@
 """Hearthstone API client.
 
-This module provides access to Hearthstone game data through the Blizzard API,
-including cards, card backs, and metadata.
+This module exposes the Hearthstone facade. Hearthstone has only one
+sub-domain (game data), but this file mirrors the structure of the other
+game packages (`wow.game_data`, `diablo3.game_data`, etc.) so the public
+API surface stays consistent.
 """
 
 from typing import Any, Dict
 
 from ..api import BaseApi
 from ..types import Locale, Region
+from .hearthstone_game_data_api import HearthstoneGameDataApi
 
 
 class ApiResponse:
@@ -20,21 +23,22 @@ class ApiResponse:
 
 
 class HearthstoneApi(BaseApi):
-    """Hearthstone API client.
+    """Hearthstone API client facade.
 
-    This class provides access to Hearthstone game data through the Blizzard API,
-    including cards, card backs, and metadata.
+    Exposes Hearthstone endpoints under ``.game_data`` for consistency with
+    the other game facades (``wow.game_data``, ``diablo3.game_data``, ...).
 
     Example:
         ```python
-        api = HearthstoneApi(client_id="your_id", client_secret="your_secret")
-        cards = api.get_cards("us", "en_US")
-        card = api.get_card("us", "en_US", "test-card")
+        api = BlizzardApi("your_id", "your_secret")
+        cards = api.hearthstone.game_data.search_cards("us", "en_US")
+        card = api.hearthstone.game_data.get_card("us", "en_US", "test-card")
         ```
 
     Attributes:
         _client_id: The Blizzard API client ID.
         _client_secret: The Blizzard API client secret.
+        game_data: The Hearthstone game-data API client.
     """
 
     def __init__(self, client_id: str, client_secret: str) -> None:
@@ -45,72 +49,4 @@ class HearthstoneApi(BaseApi):
             client_secret: The Blizzard API client secret.
         """
         super().__init__(client_id, client_secret)
-
-    def get_cards(self, region: Region, locale: Locale) -> Dict[str, Any]:
-        """Get all cards.
-
-        Args:
-            region: The region to query (e.g., "us", "eu").
-            locale: The locale to use for the response (e.g., "en_US").
-
-        Returns:
-            A dictionary containing all cards.
-
-        Raises:
-            ApiError: If the API request fails.
-        """
-        resource = "/hearthstone/cards"
-        query_params = {"locale": locale}
-        return self.get_resource(resource, region, query_params)
-
-    def get_card_backs(self, region: Region, locale: Locale) -> Dict[str, Any]:
-        """Get all card backs.
-
-        Args:
-            region: The region to query (e.g., "us", "eu").
-            locale: The locale to use for the response (e.g., "en_US").
-
-        Returns:
-            A dictionary containing all card backs.
-
-        Raises:
-            ApiError: If the API request fails.
-        """
-        resource = "/hearthstone/cardbacks"
-        query_params = {"locale": locale}
-        return self.get_resource(resource, region, query_params)
-
-    def get_metadata(self, region: Region, locale: Locale) -> Dict[str, Any]:
-        """Get metadata.
-
-        Args:
-            region: The region to query (e.g., "us", "eu").
-            locale: The locale to use for the response (e.g., "en_US").
-
-        Returns:
-            A dictionary containing metadata.
-
-        Raises:
-            ApiError: If the API request fails.
-        """
-        resource = "/hearthstone/metadata"
-        query_params = {"locale": locale}
-        return self.get_resource(resource, region, query_params)
-
-    def get_card(self, region: Region, locale: Locale, card_id: str) -> Dict[str, Any]:
-        """Get a single card.
-
-        Args:
-            region: The region to query (e.g., "us", "eu").
-            locale: The locale to use for the response (e.g., "en_US").
-            card_id: The ID of the card to retrieve.
-
-        Returns:
-            A dictionary containing the card details.
-
-        Raises:
-            ApiError: If the API request fails.
-        """
-        resource = f"/hearthstone/cards/{card_id}"
-        query_params = {"locale": locale}
-        return self.get_resource(resource, region, query_params)
+        self.game_data = HearthstoneGameDataApi(client_id, client_secret)

--- a/blizzardapi2/hearthstone/hearthstone_game_data_api.py
+++ b/blizzardapi2/hearthstone/hearthstone_game_data_api.py
@@ -115,7 +115,7 @@ class HearthstoneGameDataApi(BaseApi):
             Dict[str, Any]: A dictionary containing the deck details.
         """
         resource = "/hearthstone/deck"
-        query_params = {"locale": locale}
+        query_params = {**query_params, "locale": locale}
         return super().get_resource(resource, region, query_params)
 
     def get_metadata(self, region: str, locale: str) -> dict[str, Any]:

--- a/blizzardapi2/hearthstone/hearthstone_game_data_api.py
+++ b/blizzardapi2/hearthstone/hearthstone_game_data_api.py
@@ -24,7 +24,11 @@ class HearthstoneGameDataApi(BaseApi):
         super().__init__(client_id, client_secret)
 
     def search_cards(
-        self, region: str, locale: str, card_class: str = None, **query_params: Any
+        self,
+        region: str,
+        locale: str,
+        card_class: str | None = None,
+        **query_params: Any,
     ) -> dict[str, Any]:
         """
         Return an up-to-date list of all cards matching the search criteria.

--- a/blizzardapi2/starcraft2/starcraft2_community_api.py
+++ b/blizzardapi2/starcraft2/starcraft2_community_api.py
@@ -151,7 +151,7 @@ class Starcraft2CommunityApi(BaseApi):
         Returns:
             Dict[str, Any]: A dictionary containing the grandmaster leaderboard data.
         """
-        resource = f"/sc2/ladder/grandmaster{region_id}"
+        resource = f"/sc2/ladder/grandmaster/{region_id}"
         query_params = {"locale": locale}
         return super().get_resource(resource, region, query_params)
 

--- a/blizzardapi2/wow/wow_profile_api.py
+++ b/blizzardapi2/wow/wow_profile_api.py
@@ -43,7 +43,7 @@ class WowProfileApi(BaseApi):
             "locale": locale,
             "access_token": access_token,
         }
-        return super().get_oauth_resource(resource, region, query_params)
+        return super().get_resource(resource, region, query_params)
 
     def get_protected_character_profile_summary(
         self,

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -324,3 +324,66 @@ def test_get_oauth_resource_end_to_end(api: BaseApi, mock_get, mock_post) -> Non
     # Token in header, NOT in params.
     assert "access_token" not in mock_get.call_args.kwargs["params"]
     assert mock_get.call_args.kwargs["headers"]["Authorization"] == "Bearer user_token"
+
+
+# ---------------------------------------------------------------------------
+# HTTP timeout (issue #39)
+# ---------------------------------------------------------------------------
+
+
+def test_make_request_passes_get_timeout(api: BaseApi, mock_get) -> None:
+    """Every API GET must include `timeout=` to prevent indefinite hangs."""
+    prime_token(api)
+    api._make_request("https://us.api.blizzard.com/data/wow/realm/index", "us")
+    assert mock_get.call_args.kwargs.get("timeout") == BaseApi.DEFAULT_GET_TIMEOUT
+
+
+def test_get_client_token_passes_post_timeout(api: BaseApi, mock_post) -> None:
+    """Token POST must include `timeout=`."""
+    api._get_client_token("us")
+    assert mock_post.call_args.kwargs.get("timeout") == BaseApi.DEFAULT_POST_TIMEOUT
+
+
+def test_401_retry_get_also_passes_timeout(
+    api: BaseApi, mock_get, mock_post
+) -> None:
+    """The retry GET in the 401-refresh path must also carry a timeout."""
+    prime_token(api, token="stale")
+
+    stale = mock_get.return_value
+    stale.status_code = 401
+
+    fresh = type(stale)()
+    fresh.status_code = 200
+    fresh.json = lambda: {"ok": True}
+
+    mock_get.side_effect = [stale, fresh]
+    mock_post.return_value.json.return_value = {
+        "access_token": "fresh",
+        "expires_in": 86400,
+    }
+
+    api._make_request("https://us.api.blizzard.com/x", "us")
+
+    assert mock_get.call_count == 2
+    assert (
+        mock_get.call_args_list[0].kwargs.get("timeout")
+        == BaseApi.DEFAULT_GET_TIMEOUT
+    )
+    assert (
+        mock_get.call_args_list[1].kwargs.get("timeout")
+        == BaseApi.DEFAULT_GET_TIMEOUT
+    )
+
+
+def test_subclass_can_override_default_timeout(mock_get, fake_credentials) -> None:
+    """Subclasses override DEFAULT_*_TIMEOUT to customize per-instance."""
+
+    class FastApi(BaseApi):
+        DEFAULT_GET_TIMEOUT = 5.0
+
+    client_id, client_secret = fake_credentials
+    api = FastApi(client_id, client_secret)
+    prime_token(api)
+    api._make_request("https://us.api.blizzard.com/x", "us")
+    assert mock_get.call_args.kwargs["timeout"] == 5.0

--- a/tests/test_base_api.py
+++ b/tests/test_base_api.py
@@ -344,9 +344,7 @@ def test_get_client_token_passes_post_timeout(api: BaseApi, mock_post) -> None:
     assert mock_post.call_args.kwargs.get("timeout") == BaseApi.DEFAULT_POST_TIMEOUT
 
 
-def test_401_retry_get_also_passes_timeout(
-    api: BaseApi, mock_get, mock_post
-) -> None:
+def test_401_retry_get_also_passes_timeout(api: BaseApi, mock_get, mock_post) -> None:
     """The retry GET in the 401-refresh path must also carry a timeout."""
     prime_token(api, token="stale")
 
@@ -367,12 +365,10 @@ def test_401_retry_get_also_passes_timeout(
 
     assert mock_get.call_count == 2
     assert (
-        mock_get.call_args_list[0].kwargs.get("timeout")
-        == BaseApi.DEFAULT_GET_TIMEOUT
+        mock_get.call_args_list[0].kwargs.get("timeout") == BaseApi.DEFAULT_GET_TIMEOUT
     )
     assert (
-        mock_get.call_args_list[1].kwargs.get("timeout")
-        == BaseApi.DEFAULT_GET_TIMEOUT
+        mock_get.call_args_list[1].kwargs.get("timeout") == BaseApi.DEFAULT_GET_TIMEOUT
     )
 
 

--- a/tests/test_hearthstone.py
+++ b/tests/test_hearthstone.py
@@ -1,8 +1,8 @@
 """Tests for the Hearthstone APIs.
 
 These tests verify URL construction, query-parameter shape, and return-value
-passthrough for both ``HearthstoneApi`` (the facade exposed on
-``BlizzardApi.hearthstone``) and ``HearthstoneGameDataApi``. All HTTP is
+passthrough through ``HearthstoneApi`` (the facade exposed on
+``BlizzardApi.hearthstone``) and its ``game_data`` sub-client. All HTTP is
 patched at the ``requests.Session`` boundary via the ``mock_get`` fixture.
 """
 
@@ -28,13 +28,27 @@ def test_blizzard_api_exposes_hearthstone_facade(fake_credentials):
     assert api.hearthstone._client_secret == client_secret
 
 
-def test_get_cards_builds_us_url_with_locale(fake_credentials, mock_get):
-    """``get_cards`` hits ``/hearthstone/cards`` with the locale param."""
+def test_hearthstone_facade_exposes_game_data(fake_credentials):
+    """``HearthstoneApi.game_data`` should be a ``HearthstoneGameDataApi``.
+
+    Issue #42: the game-data client used to be orphaned (not reachable from
+    ``BlizzardApi``). It is now exposed under ``.game_data`` for consistency
+    with ``wow.game_data``, ``diablo3.game_data``, ``starcraft2.game_data``.
+    """
     client_id, client_secret = fake_credentials
     api = HearthstoneApi(client_id, client_secret)
-    prime_token(api)
+    assert isinstance(api.game_data, HearthstoneGameDataApi)
+    assert api.game_data._client_id == client_id
+    assert api.game_data._client_secret == client_secret
 
-    api.get_cards("us", "en_US")
+
+def test_search_cards_no_filters_builds_bare_cards_url(fake_credentials, mock_get):
+    """``search_cards`` with no filters hits ``/hearthstone/cards`` with locale only."""
+    client_id, client_secret = fake_credentials
+    api = HearthstoneApi(client_id, client_secret)
+    prime_token(api.game_data)
+
+    api.game_data.search_cards("us", "en_US")
 
     mock_get.assert_called_once()
     args, kwargs = mock_get.call_args
@@ -42,43 +56,43 @@ def test_get_cards_builds_us_url_with_locale(fake_credentials, mock_get):
     assert kwargs["params"] == {"locale": "en_US"}
 
 
-def test_get_card_includes_id_in_path(fake_credentials, mock_get):
-    """``get_card`` interpolates the card id into the URL path."""
+def test_get_card_includes_id_in_path_via_game_data(fake_credentials, mock_get):
+    """``game_data.get_card`` interpolates the id/slug into the URL path."""
     client_id, client_secret = fake_credentials
     api = HearthstoneApi(client_id, client_secret)
-    prime_token(api)
+    prime_token(api.game_data)
 
-    api.get_card("eu", "en_GB", "52119-arch-villain-rafaam")
+    api.game_data.get_card("eu", "en_GB", "52119-arch-villain-rafaam")
 
     args, kwargs = mock_get.call_args
     assert (
         args[0]
         == "https://eu.api.blizzard.com/hearthstone/cards/52119-arch-villain-rafaam"
     )
-    assert kwargs["params"] == {"locale": "en_GB"}
+    assert kwargs["params"] == {"locale": "en_GB", "game_mode": "constructed"}
 
 
-def test_get_cards_returns_mocked_payload(fake_credentials, mock_get):
+def test_search_cards_returns_mocked_payload(fake_credentials, mock_get):
     """The dict returned by the client should be exactly what ``json()`` returned."""
     payload = {"cards": [{"id": 1, "name": "Test Card"}], "cardCount": 1}
     mock_get.return_value.json.return_value = payload
 
     client_id, client_secret = fake_credentials
     api = HearthstoneApi(client_id, client_secret)
-    prime_token(api)
+    prime_token(api.game_data)
 
-    result = api.get_cards("us", "en_US")
+    result = api.game_data.search_cards("us", "en_US")
 
     assert result == payload
 
 
-def test_get_card_backs_uses_cn_gateway(fake_credentials, mock_get):
+def test_search_card_backs_uses_cn_gateway(fake_credentials, mock_get):
     """CN region must route to the Chinese gateway, not a regional subdomain."""
     client_id, client_secret = fake_credentials
     api = HearthstoneApi(client_id, client_secret)
-    prime_token(api)
+    prime_token(api.game_data)
 
-    api.get_card_backs("cn", "zh_CN")
+    api.game_data.search_card_backs("cn", "zh_CN")
 
     args, kwargs = mock_get.call_args
     assert args[0] == "https://gateway.battlenet.com.cn/hearthstone/cardbacks"
@@ -175,5 +189,3 @@ def test_get_deck_preserves_caller_filters(fake_credentials, mock_get):
         "ids": "EX1_046,EX1_054",
         "hero": "HERO_01",
     }
-
-

--- a/tests/test_hearthstone.py
+++ b/tests/test_hearthstone.py
@@ -149,3 +149,31 @@ def test_get_metadata_type_path_includes_type_id(fake_credentials, mock_get):
     args, kwargs = mock_get.call_args
     assert args[0] == "https://kr.api.blizzard.com/hearthstone/metadata/sets"
     assert kwargs["params"] == {"locale": "ko_KR"}
+
+
+def test_get_deck_preserves_caller_filters(fake_credentials, mock_get):
+    """``get_deck`` must forward caller-supplied filters (issue #41).
+
+    The previous implementation silently dropped every kwarg by overwriting
+    `query_params = {"locale": locale}` after the **kwargs collection.
+    """
+    client_id, client_secret = fake_credentials
+    api = HearthstoneGameDataApi(client_id, client_secret)
+    prime_token(api)
+
+    api.get_deck(
+        "us",
+        "en_US",
+        ids="EX1_046,EX1_054",
+        hero="HERO_01",
+    )
+
+    args, kwargs = mock_get.call_args
+    assert args[0] == "https://us.api.blizzard.com/hearthstone/deck"
+    assert kwargs["params"] == {
+        "locale": "en_US",
+        "ids": "EX1_046,EX1_054",
+        "hero": "HERO_01",
+    }
+
+

--- a/tests/test_starcraft2.py
+++ b/tests/test_starcraft2.py
@@ -107,7 +107,7 @@ def test_community_get_ladder_summary_returns_mocked_payload(
 
 
 def test_community_get_grandmaster_leaderboard_url_shape(fake_credentials, mock_get):
-    """Note: source concatenates region_id directly to 'grandmaster' (no slash)."""
+    """Region id sits at /sc2/ladder/grandmaster/{region_id}, not concatenated."""
     client_id, client_secret = fake_credentials
     api = Starcraft2Api(client_id, client_secret)
     prime_token(api.community)
@@ -115,8 +115,7 @@ def test_community_get_grandmaster_leaderboard_url_shape(fake_credentials, mock_
     api.community.get_grandmaster_leaderboard(region="us", locale="en_US", region_id=1)
 
     args, kwargs = mock_get.call_args
-    # This mirrors the source as written: f"/sc2/ladder/grandmaster{region_id}"
-    assert args[0] == "https://us.api.blizzard.com/sc2/ladder/grandmaster1"
+    assert args[0] == "https://us.api.blizzard.com/sc2/ladder/grandmaster/1"
     assert kwargs["params"] == {"locale": "en_US"}
 
 

--- a/tests/test_wow.py
+++ b/tests/test_wow.py
@@ -181,9 +181,9 @@ def test_oauth_token_goes_to_header_not_query(wow_api: WowApi, mock_get) -> None
     )
 
     args, kwargs = mock_get.call_args
-    # `get_account_profile_summary` calls `get_oauth_resource`, so the URL is
-    # built from OAUTH_URLS (oauth.battle.net), not the standard API host.
-    assert args[0] == "https://oauth.battle.net/profile/user/wow"
+    # /profile/user/wow lives on the regional API host, not oauth.battle.net
+    # — the OAuth host only serves /oauth/* endpoints.
+    assert args[0] == "https://us.api.blizzard.com/profile/user/wow"
     # Token in header, with Bearer prefix, using the *user* token (not the
     # primed client-credentials token).
     assert kwargs["headers"] == {"Authorization": f"Bearer {user_token}"}


### PR DESCRIPTION
Closes #39, #40, #41, #42, #44, #45, #46. (#43 was closed earlier as not-a-bug — the D3 `/d3/profile/{account-id}` endpoints are public-lookup, not user OAuth.)

## Commits, in landing order

| # | Commit | Why this order |
|---|---|---|
| #39 | `fix:` add HTTP timeouts to BaseApi requests | Foundational — every test mocks GETs/POSTs that now carry `timeout=`; doing it first means later commits don't need to retrofit. |
| #40 | `fix(sc2):` add missing slash in get_grandmaster_leaderboard URL | Standalone one-liner. |
| #44 | `fix(wow):` route get_account_profile_summary to the API host | Standalone. The OAuth host doesn't serve `/profile/user/wow`. |
| #41 | `fix(hearthstone):` preserve caller-supplied filters in get_deck | Standalone. |
| #46 | `docs:` three docstring/annotation papercuts | Cosmetic. |
| #42 | `refactor(hearthstone)!:` expose game_data, drop duplicates | **Breaking** — see below. |
| #45 | `fix(types):` widen Region in BattlenetOAuthApi, fix Optional default | Last because the #42 refactor removed the duplicated typed methods on `HearthstoneApi`, shrinking #45's surface to a single method. |

## Breaking change (#42)

Callers using `api.hearthstone.get_card(...)`, `api.hearthstone.get_cards(...)`, `api.hearthstone.get_card_backs(...)`, or `api.hearthstone.get_metadata(...)` must migrate to `api.hearthstone.game_data.<method>(...)`.

Trade-off discussed before merging: the alternative was leaving `HearthstoneGameDataApi` orphaned (its `search_cards`, `search_card_backs`, `get_deck`, and `get_metadata_type` methods weren't reachable from `BlizzardApi`). Path A — expose `.game_data` on the facade and dedupe — was chosen for consistency with `wow.game_data`, `diablo3.game_data`, `starcraft2.game_data`. Worth a minor-version note in the changelog when this releases.

## Test plan

- [x] `pytest tests/ -v` — 84 passed in 0.13s (was 78 on `main`)
- [x] `black --check .` clean across all 30 files
- [x] New behaviors covered by tests:
  - `_make_request` and `_get_client_token` carry `timeout=` (incl. the 401-retry GET)
  - Subclassing `BaseApi` to override `DEFAULT_GET_TIMEOUT` actually changes the call's timeout
  - SC2 leaderboard URL has the slash
  - WoW `get_account_profile_summary` hits `{region}.api.blizzard.com`, not `oauth.battle.net`
  - Hearthstone `get_deck` forwards caller filters
  - Hearthstone facade exposes `.game_data`
- [x] CI matrix passes on 3.11/3.12/3.13 (will see on this PR)