### PR TITLE
chore: release v3.0.0 [skip ci]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blizzardapi2",
-  "version": "2.1.22",
+  "version": "3.0.0",
   "scripts": {
     "release": "release-it"
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "blizzardapi2"
-version = "2.1.22"
+version = "3.0.0"
 description = "A Python wrapper for Blizzard API"
 authors = [{ name = "lostcol0ny", email = "c098os0k@4wrd.cc" }]
 license = "MIT"


### PR DESCRIPTION
Bumps `pyproject.toml` and `package.json` to **3.0.0** to honor SemVer for the breaking change in #42. (PyPI is currently at 2.1.22; this PR is the version-source-of-truth bump.)

## Why `[skip ci]`

The publish workflow runs `release-it` after every merge to `main`, and `release-it` auto-bumps the version from the latest git tag (currently `v2.1.22`). Without `[skip ci]`, merging this PR would:

1. Build and publish `3.0.0` to PyPI ✓
2. Then `release-it` would bump to `v2.1.23` (default patch), `sed` `pyproject.toml` back to `2.1.23`, tag `v2.1.23`, and create a GitHub release for `v2.1.23` — leaving `main` and PyPI out of sync.

The `[skip ci]` marker on the merge commit avoids that mess. PyPI publish, git tag, and GitHub release are intended to be issued manually after merge — see the manual steps in the commit body.

## Manual release steps after merge

```bash
git checkout main && git pull
.venv/bin/python -m build
.venv/bin/twine upload dist/blizzardapi2-3.0.0*
git tag v3.0.0 && git push origin v3.0.0
gh release create v3.0.0 --title "Release v3.0.0" --notes "<paste the release notes below>"
```

## Release notes (copy into `gh release create --notes`)

> **3.0.0 is a major-version release because of one breaking change in the Hearthstone facade. The other seven changes are non-breaking bug fixes and improvements.**
>
> ### ⚠️ Breaking change
>
> `HearthstoneApi` no longer defines endpoint methods directly. The facade now exposes a `.game_data` sub-client matching the layout of `wow.game_data`, `diablo3.game_data`, and `starcraft2.game_data`.
>
> Callers using:
> ```python
> api.hearthstone.get_card(...)
> api.hearthstone.get_cards(...)
> api.hearthstone.get_card_backs(...)
> api.hearthstone.get_metadata(...)
> ```
> must migrate to:
> ```python
> api.hearthstone.game_data.get_card(...)
> api.hearthstone.game_data.search_cards(...)        # was get_cards()
> api.hearthstone.game_data.search_card_backs(...)   # was get_card_backs()
> api.hearthstone.game_data.get_metadata(...)
> ```
>
> This unblocks four endpoints that were previously orphaned (not reachable from `BlizzardApi` at all): `search_cards`, `search_card_backs`, `get_deck`, and `get_metadata_type`. (#42)
>
> ### Bug fixes
>
> - **No more indefinite hangs.** `BaseApi` now sends a timeout on every request (30s for GETs, 10s for the token POST). Subclass `BaseApi` and override `DEFAULT_GET_TIMEOUT` / `DEFAULT_POST_TIMEOUT` to customize. (#39)
> - **SC2 grandmaster leaderboard URL** had a missing slash (`/sc2/ladder/grandmaster1` instead of `/sc2/ladder/grandmaster/1`). Fixed. (#40)
> - **WoW account-profile-summary** was routing to `oauth.battle.net`, which doesn't serve `/profile/user/wow` (404). Now routes to `{region}.api.blizzard.com`. (#44)
> - **Hearthstone `get_deck`** silently dropped caller-supplied filters; now forwards them. (#41)
>
> ### Type hints
>
> - `BattlenetOAuthApi.get_user_info` now accepts `region: Region | str` (was `Region` only). Pure widening — no runtime change. (#45)
> - `HearthstoneGameDataApi.search_cards`: `card_class: str | None = None` (was incorrectly typed as `str = None`). (#45)
>
> ### Documentation
>
> Three docstring/annotation papercuts cleaned up in `BattlenetApi`, `BattlenetOAuthApi`, and `Diablo3CommunityApi`. (#46)
>
> ### Tooling improvements (shipped in 2.1.20 / 2.1.21)
>
> The 2.x series added a 78-test pytest suite, CI gated on a 3.11/3.12/3.13 test matrix, and version-pinned `black` checks across CI / pre-commit / `[dev]` extra to prevent formatter drift.

## Test plan

- [x] `pytest tests/` passes (84 tests, unchanged from `main` post-#47)
- [x] `python -m build` produces `blizzardapi2-3.0.0.tar.gz` + wheel
- [x] Built wheel METADATA shows `Version: 3.0.0`
- [ ] Manual PyPI upload + tag + GitHub release (post-merge)