### PR TITLE
chore(ci): reorder release pipeline so PyPI version matches GitHub tag

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -43,56 +43,15 @@ jobs:
       - name: Run tests
         run: uv run pytest tests/ -v
 
-  publish:
+  release:
     needs: test
     if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Create virtual environment
-        run: |
-          uv venv
-
-      - name: Install dependencies
-        run: |
-          uv pip install -e ".[dev]"
-      - name: Configure Git
-        run: |
-          git config --global user.name "lostcol0ny"
-          git config --global user.email "c098os0k@4wrd.cc"
-
-      - name: Build and publish to PyPI
-        run: |
-          python -m pip install --upgrade pip
-          pip install build twine setuptools_scm
-          python -m build
-          twine upload dist/* --skip-existing --username __token__ --password ${{ secrets.PYPI_API_TOKEN }} || {
-            echo "Upload failed - version may already exist or filename was previously used"
-            echo "This is expected behavior and won't block the release"
-            exit 0
-          }
-        env:
-          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-
-  release:
-    needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
       id-token: write
+    outputs:
+      tag: ${{ steps.bump.outputs.tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -122,16 +81,36 @@ jobs:
           && sudo apt install gh -y
 
       - name: Run release script
+        id: bump
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Debug: Check current version
-          echo "Current package.json version: $(node -p "require('./package.json').version")"
-          echo "Current pyproject.toml version: $(grep 'version = ' pyproject.toml | head -n 1 | cut -d'"' -f2)"
-
-          # Run release-it with CI mode
           npx release-it --ci || {
             echo "release-it failed, creating GitHub release manually..."
             VERSION=$(node -p "require('./package.json').version")
             gh release create "v$VERSION" --title "Release v$VERSION" --notes "Release v$VERSION"
           }
+          tag=$(git describe --tags --abbrev=0)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.tag }}
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Build and publish to PyPI
+        env:
+          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine upload dist/* --skip-existing --username __token__ --password "$PYPI_API_TOKEN"

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,6 +1,6 @@
 {
   "git": {
-    "commitMessage": "chore: release v${version}",
+    "commitMessage": "chore: release v${version} [skip ci]",
     "tagName": "v${version}"
   },
   "github": {


### PR DESCRIPTION
## Summary

Fixes a longstanding off-by-one between PyPI artifact versions and GitHub release tags, plus a silent-failure swallow on the upload step.

**Before:** `test → publish → release-it` — publish built and uploaded a dist using whatever version was in `pyproject.toml` *before* release-it bumped it. Result: PyPI v3.0.1 contains the code tagged v3.0.2 on GitHub, and v3.0.2 was never uploaded to PyPI at all.

**After:** `test → release-it → publish` — release-it runs first, exposes the resulting tag as a job output, and publish checks out at that exact tag. PyPI artifact name and GitHub release tag always agree.

## What changes

- Reorder jobs: `test → release → publish`
- `release` job declares an output (`tag`) read from `git describe --tags --abbrev=0` after release-it runs
- `publish` job checks out `${{ needs.release.outputs.tag }}` instead of the workflow-trigger SHA
- Drop `|| { ... exit 0 }` swallow on `twine upload`; real failures now fail the workflow loudly. `--skip-existing` already handles the version-already-exists case without erroring.
- Drop redundant `setuptools_scm` install in publish (no longer reading version dynamically — the bumped `pyproject.toml` is authoritative)
- `[skip ci]` added to release-it's commit message so the bump commit no longer triggers a redundant second workflow run

## Note on the existing off-by-one

The current state is accepted forward: PyPI 3.0.1 contains the StrEnum fix from #52 (which closed #50), so users are getting the intended bug-fix code under what looks like the wrong version label. The first release after this PR merges will bump cleanly and PyPI will catch up.

## Test plan

- [x] Merge this PR and verify the resulting workflow run produces a single tag-PyPI alignment (next `chore: release vX.Y.Z` commit on main should be tagged with the same version that's uploaded to PyPI)
- [ ] Verify `[skip ci]` on the release-it commit prevents a redundant second workflow run
- [ ] If `twine upload` ever fails for real (rotated token, network blip), the workflow should now go red instead of green