### PR TITLE
chore: drop releaseNotes shell-eval from release-it config

### DIFF
--- a/.release-it.cjs
+++ b/.release-it.cjs
@@ -37,7 +37,6 @@ module.exports = {
   github: {
     release: true,
     releaseName: "Release v${version}",
-    releaseNotes: "${changelog}",
   },
   npm: {
     publish: false,


### PR DESCRIPTION
## Why

The v5.0.0 release attempt on merge of #66 failed at the `release` job. release-it's `github.releaseNotes: "${changelog}"` is documented as a shell command whose stdout becomes the release body — with the changelog interpolated, the entire markdown got piped to `sh -c`. The `* ...` bullets glob-expanded (matching `CLAUDE.md` first alphabetically) and `(was /oauth/userinfo)` parsed as subshell syntax.

Action log excerpt:

```
ERROR /bin/sh: 5: CLAUDE.md: not found
/bin/sh: 6: session: not found
/bin/sh: 8: Syntax error: "(" unexpected
```

## Fix

Remove the `releaseNotes` line. release-it falls back to the conventional-changelog plugin output as the release body — which is what we wanted anyway.

## Effect on v5.0.0

The `feat!:` squash commit from #66 (`00deb0d`) is still in the unreleased window. Once this PR merges, the next workflow run on main will see `feat!:` + this `chore:` since the last tag (`v4.0.2`), and `whatBump` will return `level: 0` → **v5.0.0 cuts cleanly**.

## Verification

No PyPI side effects from the failed run — `publish` was skipped, no `v5.0.0` tag landed on origin.