### PR TITLE
ci: use RELEASE_TOKEN PAT for release-it git push

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -60,6 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Configure Git
         run: |
@@ -86,7 +87,7 @@ jobs:
       - name: Run release script
         id: bump
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           npx release-it --ci || {
             echo "release-it failed, creating GitHub release manually..."


### PR DESCRIPTION
## Why

After the v5.0.0 release attempt (squash of #66) and its follow-up fix (#67), the release-it git push to main was rejected by the `test_checks` ruleset:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - 4 of 4 required status checks are expected.
```

The same ruleset existed when v4.0.2 shipped successfully on 2026-05-07 — but GitHub backend enforcement around `do_not_enforce_on_create: false` tightened in early 2026, so `[skip ci]` release-it commits without check results are now blocked on direct push.

Personal-repo rulesets can't add the GitHub Actions integration as a bypass actor (returns `422: must be part of the ruleset source or owner organization`), so the workaround is to push as an admin user via a maintainer-supplied PAT.

## What this does

- `actions/checkout@v4` configured with `token: ${{ secrets.RELEASE_TOKEN }}` so the credential helper uses the PAT for subsequent git push
- The release step's `GITHUB_TOKEN` env var (which release-it reads for GitHub release creation) is swapped to `RELEASE_TOKEN`
- Test/format jobs continue to use the default `GITHUB_TOKEN`

## Before merging

1. Create a fine-grained PAT scoped to **only this repo** with permission **Contents: read and write**. (Optionally also Workflows: read and write — only needed if release-it ever modifies workflow files, which it doesn't here.)
2. Save it as repository secret `RELEASE_TOKEN`.

The ruleset has already been updated to allow `RepositoryRole admin` (`bypass_mode: always`) as a bypass actor, so once the PAT is in place the push will go through.

## Effect on v5.0.0

The `feat!:` squash from #66 is still in the unreleased window. Once this PR merges with the secret in place, release-it will see the breaking change, bump to v5.0.0, push the version bump (now under PAT auth → bypass succeeds), tag, GitHub-release, and publish to PyPI.