### PR TITLE
chore(deps): bump pygments to 2.20.0 (GHSA-5239-wwwm-4pmq)

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -494,11 +494,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.19.1"
+version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581, upload-time = "2025-01-06T17:26:30.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293, upload-time = "2025-01-06T17:26:25.553Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps Pygments 2.19.1 → 2.20.0 in `uv.lock` to address Dependabot alert #25.

## Vulnerability
- **Advisory:** GHSA-5239-wwwm-4pmq / CVE-2026-4539
- **Severity:** Low (CVSS 3.3 — local-access ReDoS in `AdlLexer`)
- **Fixed version:** 2.20.0

## Impact on this package
Pygments is a **transitive dev-only dependency** (pulled in by `pytest`, `rich`, and `readme_renderer`/`twine`). It's not part of the published runtime surface, so this has no effect on consumers of `blizzardapi2`. Bumping it just clears the Dependabot alert.

## Verification
```
$ grep -A1 'name = "pygments"' uv.lock | head
name = "pygments"
version = "2.20.0"
```

Dependabot alert #25 will auto-close on merge.