### PR TITLE
chore: ignore .claude.local.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ dmypy.json
 
 # Claude Code
 .claude
+.claude.local.md
 
 # Test project
 test_project/


### PR DESCRIPTION
Adds `.claude.local.md` to `.gitignore`. It's a local-only Claude Code scratch file (sibling of the already-ignored `.claude` directory) that shouldn't be tracked.